### PR TITLE
Fixed loading single player worlds with mod enabled

### DIFF
--- a/src/main/java/com/skaggsm/mumblelinkmod/mixin/MixinIntegratedServer.java
+++ b/src/main/java/com/skaggsm/mumblelinkmod/mixin/MixinIntegratedServer.java
@@ -1,0 +1,21 @@
+package com.skaggsm.mumblelinkmod.mixin;
+
+import com.skaggsm.mumblelinkmod.ClientMumbleLinkMod;
+import com.skaggsm.mumblelinkmod.ClientMumbleLinkModKt;
+import net.minecraft.server.integrated.IntegratedServer;
+import net.minecraft.world.GameMode;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(IntegratedServer.class)
+public abstract class MixinIntegratedServer {
+
+	@Inject(method = "openToLan", at = @At(value = "HEAD"))
+	public void openToLan(GameMode gameMode, boolean cheatsAllowed, int port, CallbackInfoReturnable<Boolean> ci) {
+		ClientMumbleLinkModKt.setOpenedLan(true);
+		ClientMumbleLinkMod.INSTANCE.onInitializeClient();
+	}
+
+}

--- a/src/main/java/com/skaggsm/mumblelinkmod/mixin/MixinPlayerManager.java
+++ b/src/main/java/com/skaggsm/mumblelinkmod/mixin/MixinPlayerManager.java
@@ -2,9 +2,12 @@ package com.skaggsm.mumblelinkmod.mixin;
 
 import com.skaggsm.mumblelinkmod.ServerOnConnectCallback;
 import net.minecraft.network.ClientConnection;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.PlayerManager;
 import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -15,8 +18,11 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
  */
 @Mixin(PlayerManager.class)
 public class MixinPlayerManager {
+    @Shadow @Final private MinecraftServer server;
+
     @Inject(method = "onPlayerConnect", at = @At("RETURN"), locals = LocalCapture.CAPTURE_FAILEXCEPTION)
     private void onPlayerConnect(ClientConnection connection, ServerPlayerEntity player, CallbackInfo ci) {
-        ServerOnConnectCallback.EVENT.invoker().onConnect(player);
+        if (server.isDedicated())
+            ServerOnConnectCallback.EVENT.invoker().onConnect(player);
     }
 }

--- a/src/main/java/com/skaggsm/mumblelinkmod/mixin/MixinPlayerManager.java
+++ b/src/main/java/com/skaggsm/mumblelinkmod/mixin/MixinPlayerManager.java
@@ -1,5 +1,6 @@
 package com.skaggsm.mumblelinkmod.mixin;
 
+import com.skaggsm.mumblelinkmod.ClientMumbleLinkModKt;
 import com.skaggsm.mumblelinkmod.ServerOnConnectCallback;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.server.MinecraftServer;
@@ -22,7 +23,7 @@ public class MixinPlayerManager {
 
     @Inject(method = "onPlayerConnect", at = @At("RETURN"), locals = LocalCapture.CAPTURE_FAILEXCEPTION)
     private void onPlayerConnect(ClientConnection connection, ServerPlayerEntity player, CallbackInfo ci) {
-        if (server.isDedicated())
+        if (server.isDedicated() || ClientMumbleLinkModKt.getOpenedLan())
             ServerOnConnectCallback.EVENT.invoker().onConnect(player);
     }
 }

--- a/src/main/java/com/skaggsm/mumblelinkmod/mixin/MixinServerPlayerEntity.java
+++ b/src/main/java/com/skaggsm/mumblelinkmod/mixin/MixinServerPlayerEntity.java
@@ -2,9 +2,12 @@ package com.skaggsm.mumblelinkmod.mixin;
 
 import com.skaggsm.mumblelinkmod.ServerOnChangeWorldCallback;
 import net.minecraft.entity.Entity;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -14,8 +17,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
  */
 @Mixin(ServerPlayerEntity.class)
 public abstract class MixinServerPlayerEntity {
+    @Shadow @Final public MinecraftServer server;
+
     @Inject(method = "moveToWorld", at = @At(value = "RETURN"))
     private void onChangeDimension(ServerWorld destination, CallbackInfoReturnable<Entity> cir) {
-        ServerOnChangeWorldCallback.EVENT.invoker().onChangeDimension(destination.getRegistryKey(), (ServerPlayerEntity) (Object) this);
+        if (server.isDedicated())
+            ServerOnChangeWorldCallback.EVENT.invoker().onChangeDimension(destination.getRegistryKey(), (ServerPlayerEntity) (Object) this);
     }
 }

--- a/src/main/java/com/skaggsm/mumblelinkmod/mixin/MixinServerPlayerEntity.java
+++ b/src/main/java/com/skaggsm/mumblelinkmod/mixin/MixinServerPlayerEntity.java
@@ -1,5 +1,6 @@
 package com.skaggsm.mumblelinkmod.mixin;
 
+import com.skaggsm.mumblelinkmod.ClientMumbleLinkModKt;
 import com.skaggsm.mumblelinkmod.ServerOnChangeWorldCallback;
 import net.minecraft.entity.Entity;
 import net.minecraft.server.MinecraftServer;
@@ -21,7 +22,7 @@ public abstract class MixinServerPlayerEntity {
 
     @Inject(method = "moveToWorld", at = @At(value = "RETURN"))
     private void onChangeDimension(ServerWorld destination, CallbackInfoReturnable<Entity> cir) {
-        if (server.isDedicated())
+        if (server.isDedicated() || ClientMumbleLinkModKt.getOpenedLan())
             ServerOnChangeWorldCallback.EVENT.invoker().onChangeDimension(destination.getRegistryKey(), (ServerPlayerEntity) (Object) this);
     }
 }

--- a/src/main/kotlin/com/skaggsm/mumblelinkmod/ClientMumbleLinkMod.kt
+++ b/src/main/kotlin/com/skaggsm/mumblelinkmod/ClientMumbleLinkMod.kt
@@ -20,6 +20,8 @@ import java.awt.GraphicsEnvironment
 import java.net.URI
 import java.net.URISyntaxException
 
+var openedLan: Boolean = false
+
 /**
  * Convert to a float 3-array in a left-handed coordinate system.
  * Minecraft is right-handed by default, Mumble needs left-handed.
@@ -61,11 +63,11 @@ object ClientMumbleLinkMod : ClientModInitializer {
         }
 
         ClientTickEvents.START_CLIENT_TICK.register(ClientTickEvents.StartTick {
-            if (!it.isIntegratedServerRunning) {
-                val world = it.world
-                val player = it.player
+            val world = it.world
+            val player = it.player
 
-                if (world != null && player != null) {
+            if (world != null && player != null) {
+                if (!it.isIntegratedServerRunning || openedLan) {
                     val mumble = ensureLinked()
 
                     val camPos = player.getCameraPosVec(1F).toLHArray
@@ -94,9 +96,9 @@ object ClientMumbleLinkMod : ClientModInitializer {
                     mumble.context = "Minecraft"
 
                     mumble.description = "A Minecraft mod that provides position data to VoIP clients."
-                } else {
-                    ensureClosed()
                 }
+            } else {
+                ensureClosed()
             }
         })
     }
@@ -121,6 +123,7 @@ object ClientMumbleLinkMod : ClientModInitializer {
             mumble?.close()
             mumble = null
             log.info("Unlinked")
+            openedLan = false
         }
     }
 

--- a/src/main/kotlin/com/skaggsm/mumblelinkmod/ClientMumbleLinkMod.kt
+++ b/src/main/kotlin/com/skaggsm/mumblelinkmod/ClientMumbleLinkMod.kt
@@ -61,40 +61,42 @@ object ClientMumbleLinkMod : ClientModInitializer {
         }
 
         ClientTickEvents.START_CLIENT_TICK.register(ClientTickEvents.StartTick {
-            val world = it.world
-            val player = it.player
+            if (!it.isIntegratedServerRunning) {
+                val world = it.world
+                val player = it.player
 
-            if (world != null && player != null) {
-                val mumble = ensureLinked()
+                if (world != null && player != null) {
+                    val mumble = ensureLinked()
 
-                val camPos = player.getCameraPosVec(1F).toLHArray
-                val camDir = player.rotationVecClient.toLHArray
-                val camTop = floatArrayOf(0f, 1f, 0f)
+                    val camPos = player.getCameraPosVec(1F).toLHArray
+                    val camDir = player.rotationVecClient.toLHArray
+                    val camTop = floatArrayOf(0f, 1f, 0f)
 
-                // Make people in other dimensions far away so that they're muted.
-                val yAxisAdjuster = world.dimension.hashCode() * config.config.mumbleDimensionYAxisAdjust
-                camPos[1] += yAxisAdjuster
+                    // Make people in other dimensions far away so that they're muted.
+                    val yAxisAdjuster = world.dimension.hashCode() * config.config.mumbleDimensionYAxisAdjust
+                    camPos[1] += yAxisAdjuster
 
-                mumble.uiVersion = 2
-                mumble.uiTick++
+                    mumble.uiVersion = 2
+                    mumble.uiTick++
 
-                mumble.avatarPosition = camPos
-                mumble.avatarFront = camDir
-                mumble.avatarTop = camTop
+                    mumble.avatarPosition = camPos
+                    mumble.avatarFront = camDir
+                    mumble.avatarTop = camTop
 
-                mumble.name = "Minecraft Mumble Link Mod"
+                    mumble.name = "Minecraft Mumble Link Mod"
 
-                mumble.cameraPosition = camPos
-                mumble.cameraFront = camDir
-                mumble.cameraTop = camTop
+                    mumble.cameraPosition = camPos
+                    mumble.cameraFront = camDir
+                    mumble.cameraTop = camTop
 
-                mumble.identity = player.uuidAsString
+                    mumble.identity = player.uuidAsString
 
-                mumble.context = "Minecraft"
+                    mumble.context = "Minecraft"
 
-                mumble.description = "A Minecraft mod that provides position data to VoIP clients."
-            } else {
-                ensureClosed()
+                    mumble.description = "A Minecraft mod that provides position data to VoIP clients."
+                } else {
+                    ensureClosed()
+                }
             }
         })
     }

--- a/src/main/resources/fabric-mumblelink-mod.mixins.json
+++ b/src/main/resources/fabric-mumblelink-mod.mixins.json
@@ -3,6 +3,7 @@
   "package": "com.skaggsm.mumblelinkmod.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "MixinIntegratedServer",
     "MixinPlayerManager",
     "MixinServerPlayerEntity",
     "MixinServerScoreboard"


### PR DESCRIPTION
Checks to make sure the server is a dedicated server before linking to mumble in order to fix unneeded strain and also fix the crash which occurs.

MixinPlayerManager.java:
MixinServerPlayerEntity.java:
• I added a check to fix crashes

ClientMumbleLinkMod.kt:
• I added a check to remove unneeded strain on the singleplayer world